### PR TITLE
More scheduling improvements (CPU and GPU)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ target_link_libraries(backprojection.generator PRIVATE Halide::Generator)
 add_halide_library(backprojection FROM backprojection.generator
                                   FEATURES large_buffers)
 add_halide_library(backprojection_cuda FROM backprojection.generator
-                                       FEATURES large_buffers cuda)
+                                       FEATURES large_buffers cuda
+                                       PARAMS blocksize=1024)
 
 add_executable(img_output.generator img_output.cpp)
 target_link_libraries(img_output.generator PRIVATE Halide::Generator)


### PR DESCRIPTION
This PR contains 2 logical changes:
1.  Rename `Var`s to make the shape of computation clearer.  (ex. `x, y` → `pulse, pixel`)
2.  Improve CPU and GPU scheduling to reduce memory usage.

The reduction in memory usage has a corresponding performance increase.  Notably, it allows running the Sandia dataset on GPU, which is an Inf% performance increase over the previous (crashy) behavior.

CPU/Hostmem[/GPUmem] before:
```
AFRL CPU: 421ms/995MB
AFRL GPU: 299ms/153MB/1101MB
Sandia CPU: 76759ms/67273MB
Sandia GPU: crash, CUDA_ERROR_OUT_OF_MEMORY
```

And after:
```
AFRL CPU: 414ms/57MB
AFRL GPU: 313ms/15MB/141MB
Sandia CPU: 45105ms/394MB
Sandia GPU: 8665ms/262MB/471MB
```

(This is on a noisy development machine.  My runtimes vary ± 10% across runs.)