### PR TITLE
Put the taylor function in a Taylor class

### DIFF
--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -108,9 +108,9 @@ public:
         rnd = RDom(0, nd, "rnd");
 
         // Create window: produces shape {nsamples, npulses}
-        win_sample(sample) = taylor(nsamples, taylor_s_l, sample, "win_sample");
-        win_pulse(pulse) = taylor(npulses, taylor_s_l, pulse, "win_pulse");
-        win(sample, pulse) = win_sample(sample) * win_pulse(pulse);
+        win_sample = Taylor(nsamples, taylor_s_l, sample, "win_sample");
+        win_pulse = Taylor(npulses, taylor_s_l, pulse, "win_pulse");
+        win(sample, pulse) = win_sample.series(sample) * win_pulse.series(pulse);
 #if DEBUG_WIN
         out_win(sample, pulse) = win(sample, pulse);
 #endif
@@ -231,8 +231,8 @@ public:
             std::cout << "Scheduling for GPU: " << tgt << std::endl
                       << "Block size: " << blocksize.value() << std::endl;
             Var pixeli{"pixeli"}, block{"block"};
-            win_sample.compute_root();
-            win_pulse.compute_root();
+            win_sample.series.compute_root();
+            win_pulse.series.compute_root();
             win.compute_root();
             filt.compute_root();
             phs_filt.inner.compute_root();
@@ -258,8 +258,8 @@ public:
                       << "Block size: " << blocksize.value() << std::endl
                       << "Vector size: " << vectorsize.value() << std::endl;
             Var pixeli{"pixeli"}, block{"block"};
-            win_sample.compute_root();
-            win_pulse.compute_root();
+            win_sample.series.compute_root();
+            win_pulse.series.compute_root();
             win.compute_root();
             filt.compute_root();
             phs_filt.inner.compute_root();
@@ -288,8 +288,8 @@ private:
     Var x{"x"}, y{"y"};
     Var c{"c"}, sample{"sample"}, pixel{"pixel"}, pulse{"pulse"}, dim{"dim"};
 
-    Func win_sample{"win_sample"};
-    Func win_pulse{"win_pulse"};
+    Taylor win_sample;
+    Taylor win_pulse;
     Func win{"win"};
     Func filt{"filt"};
     ComplexFunc phs_filt{c, "phs_filt"};

--- a/backprojection_ritsar.cpp
+++ b/backprojection_ritsar.cpp
@@ -116,9 +116,9 @@ public:
         RDom rnd(0, nd, "rnd");
 
         // Create window: produces shape {nsamples, npulses}
-        win_x(x) = taylor(nsamples, taylor_s_l, x, "win_x");
-        win_y(y) = taylor(npulses, taylor_s_l, y, "win_y");
-        win(x, y) = win_x(x) * win_y(y);
+        win_x = Taylor(nsamples, taylor_s_l, x, "win_x");
+        win_y = Taylor(npulses, taylor_s_l, y, "win_y");
+        win(x, y) = win_x.series(x) * win_y.series(y);
 #if DEBUG_WIN
         out_win(x, y) = win(x, y);
 #endif
@@ -227,8 +227,8 @@ public:
     void schedule() {
         switch (sched) {
         case Schedule::Serial:
-            win_x.compute_root();
-            win_y.compute_root();
+            win_x.series.compute_root();
+            win_y.series.compute_root();
             win.compute_root();
             filt.compute_root();
             phs_filt.inner.compute_root();
@@ -248,8 +248,8 @@ public:
             output_img.compute_root();
             break;
         case Schedule::Vectorize:
-            win_x.compute_root().vectorize(x, vectorsize);
-            win_y.compute_root().vectorize(y, vectorsize);
+            win_x.series.compute_root().vectorize(x, vectorsize);
+            win_y.series.compute_root().vectorize(y, vectorsize);
             win.compute_root().vectorize(x, vectorsize);
             filt.compute_root().vectorize(x, vectorsize);
             phs_filt.inner.compute_root().vectorize(x, vectorsize);
@@ -271,8 +271,8 @@ public:
             break;
         case Schedule::Parallel:
             // TODO: can win_x and win_y be parallelized?
-            win_x.compute_root();
-            win_y.compute_root();
+            win_x.series.compute_root();
+            win_y.series.compute_root();
             win.compute_root().parallel(y);
             filt.compute_root().parallel(x);
             phs_filt.inner.compute_root().parallel(y);
@@ -294,8 +294,8 @@ public:
             break;
         case Schedule::VectorizeParallel:
             // TODO: can win_x and win_y be parallelized?
-            win_x.compute_root().vectorize(x, vectorsize);
-            win_y.compute_root().vectorize(y, vectorsize);
+            win_x.series.compute_root().vectorize(x, vectorsize);
+            win_y.series.compute_root().vectorize(y, vectorsize);
             win.compute_root().vectorize(x, vectorsize).parallel(y);
             filt.compute_root().vectorize(x, vectorsize).parallel(x);
             phs_filt.inner.compute_root().vectorize(x, vectorsize).parallel(y);
@@ -322,8 +322,8 @@ public:
 private:
     Var c{"c"}, x{"x"}, y{"y"}, z{"z"};
 
-    Func win_x{"win_x"};
-    Func win_y{"win_y"};
+    Taylor win_x;
+    Taylor win_y;
     Func win{"win"};
     Func filt{"filt"};
     ComplexFunc phs_filt{c, "phs_filt"};

--- a/signal.h
+++ b/signal.h
@@ -11,32 +11,43 @@ using namespace Halide;
 #define M_PI 3.14159265358979323846
 #endif
 
-inline Expr taylor(Expr num, Expr S_L, Var x, const std::string &inner_name_prefix = "taylor") {
-    // need to define our domain
-    RDom n(0, num, "n");
+struct Taylor {
+    RDom n;
+    RDom r;
+    Func F_m_num;
+    Func F_m_den;
+    Func F_m;
+    Func w;
+    Func series;
 
-    Expr xi = linspace(Expr(-0.5), Expr(0.5), num, x);
-    Expr A = Expr(1.0 / (double)M_PI) * acosh(pow(10, S_L * Expr(1.0/20)));
-    Expr n_bar = ConciseCasts::i32(2 * pow(A, 2) + Expr(0.5)) + Expr(1);
-    Expr sigma_p = n_bar / sqrt(pow(A, 2) + (pow(n_bar - Expr(0.5), 2)));
+    Taylor() {}
+    Taylor(Expr num, Expr S_L, Var x, const std::string &inner_name_prefix = "taylor") {
+        n = RDom(0, num, "n");
 
-    Func F_m_num(inner_name_prefix + "_F_m_num");
-    Func F_m_den(inner_name_prefix + "_F_m_den");
-    Func F_m(inner_name_prefix + "_F_m");
-    RDom r = RDom(0, n_bar - 1, inner_name_prefix + "_r");
-    F_m_num(x) = Expr(1.0);
-    F_m_den(x) = Expr(1.0);
-    F_m_num(x) *= pow(-1, x + 2) * (Expr(1.0) - pow(x + 1, 2) / pow(sigma_p, 2) / (pow(A, 2) + pow(r.x + Expr(0.5), 2)));
-    F_m_den(x) = select(x == r.x, F_m_den(x), F_m_den(x) * (Expr(1.0) - pow(x + 1, 2) / pow(r.x + 1, 2)));
-    F_m(x) = F_m_num(x) / F_m_den(x);
+        Expr xi = linspace(Expr(-0.5), Expr(0.5), num, x);
+        Expr A = Expr(1.0 / (double)M_PI) * acosh(pow(10, S_L * Expr(1.0/20)));
+        Expr n_bar = ConciseCasts::i32(2 * pow(A, 2) + Expr(0.5)) + Expr(1);
+        Expr sigma_p = n_bar / sqrt(pow(A, 2) + (pow(n_bar - Expr(0.5), 2)));
 
-    Func w(inner_name_prefix + "_w");
-    w(x) = Expr(1.0);
-    w(x) += F_m(r) * cos(Expr(2 * (double)M_PI) * (r + 1) * xi);
+        F_m_num = Func(inner_name_prefix + "_F_m_num");
+        F_m_den = Func(inner_name_prefix + "_F_m_den");
+        F_m = Func(inner_name_prefix + "_F_m");
+        r = RDom(0, n_bar - 1, inner_name_prefix + "_r");
+        F_m_num(x) = Expr(1.0);
+        F_m_den(x) = Expr(1.0);
+        F_m_num(x) *= pow(-1, x + 2) * (Expr(1.0) - pow(x + 1, 2) / pow(sigma_p, 2) / (pow(A, 2) + pow(r.x + Expr(0.5), 2)));
+        F_m_den(x) = select(x == r.x, F_m_den(x), F_m_den(x) * (Expr(1.0) - pow(x + 1, 2) / pow(r.x + 1, 2)));
+        F_m(x) = F_m_num(x) / F_m_den(x);
 
-    // separate iteration domain (RDom) to get maximum
-    return w(x) / maximum(w(n), inner_name_prefix + "_maximum");
-}
+        w = Func(inner_name_prefix + "_w");
+        w(x) = Expr(1.0);
+        w(x) += F_m(r) * cos(Expr(2 * (double)M_PI) * (r + 1) * xi);
+
+        // separate iteration domain (RDom) to get maximum
+        series = Func(inner_name_prefix);
+        series(x) = w(x) / maximum(w(n), inner_name_prefix + "_maximum");
+    }
+};
 
 // Normalizes dB between 0 and 1, then scales by Type t's max (e.g., UInt(8) or UInt(16))
 // Return type depends on dB, but can then be safely cast to Type t

--- a/test/taylor.cpp
+++ b/test/taylor.cpp
@@ -8,11 +8,13 @@ class TaylorGenerator : public Halide::Generator<TaylorGenerator> {
 public:
     Input<int> nsamples {"nsamples"};
     Input<float> S_L {"S_L"};
+    Taylor taylor;
     Output<Buffer<double>> output{"output", 1};
 
     void generate() {
         Var x{"x"};
-        output(x) = taylor(nsamples, S_L, x);
+        taylor = Taylor(nsamples, S_L, x);
+        output(x) = taylor.series(x);
     }
 };
 


### PR DESCRIPTION
The `taylor()` function declares a few intermediate Funcs and RDoms as local variables, which means they are not accessible to scheduler code that runs later.

Make a simple Taylor class that contains intermediate Funcs, RDoms and the final result Func, so they can be referred to later.
