### PR TITLE
Add autoscheduler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ add_halide_library(backprojection_cuda FROM backprojection.generator
                                                 large_buffers
                                                 cuda
                                        PARAMS blocksize=1024)
+add_halide_library(backprojection_auto_m16 FROM backprojection.generator
+                                           FEATURES c_plus_plus_name_mangling
+                                                    large_buffers
+                                           AUTOSCHEDULER Halide::Mullapudi2016)
 
 add_executable(img_output.generator img_output.cpp)
 target_link_libraries(img_output.generator PRIVATE Halide::Generator)
@@ -112,5 +116,6 @@ target_link_libraries(sarbp_test PRIVATE Halide::Halide
                                          backprojection_ritsar_s
                                          backprojection_ritsar_p
                                          backprojection_ritsar_vp
+                                         backprojection_auto_m16
                                          img_output_u8
                                          img_output_to_dB)

--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ or with a GPU CUDA schedule:
 ```sh
 ./sarbp_test ../data/Sandia/npy 30 2 output-Sandia.png -45.0 0.0 cuda
 ```
+
+or with the Mullapudi2016 autoscheduler (for CPU):
+
+```sh
+./sarbp_test ../data/Sandia/npy 30 2 output-Sandia.png -45.0 0.0 auto-m16
+```

--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -215,17 +215,16 @@ public:
         Target tgt(target);
         if(auto_schedule) {
             std::cout << "setting size/scalar estimates for autoscheduler" << std::endl;
-            phs.set_estimates({{0, 2}, {0, 424}, {0, 469}});
-            k_r.set_estimates({{0, 424}});
-            u.set_estimates({{0, 512}});
-            v.set_estimates({{0, 512}});
-            pos.set_estimates({{0, 3}, {0, 469}});
-            r.set_estimates({{0, 262144}, {0, 3}});
-            output_img.set_estimates({{0, 2}, {0, 512}, {0, 512}});
-            delta_r.set_estimate(0.240851);
-            N_fft.set_estimate(1024);
-            taylor_s_l.set_estimate(17);
-            fftsh.inner.compute_root(); // helps the Mullapudi2016 autoscheduler pass full vectors of input to DFT
+            phs.set_estimates({{0, 2}, {0, 1800}, {0, 1999}});
+            k_r.set_estimates({{0, 1800}});
+            u.set_estimates({{0, 2048}});
+            v.set_estimates({{0, 2048}});
+            pos.set_estimates({{0, 3}, {0, 1999}});
+            r.set_estimates({{0, 4194304}, {0, 3}});
+            output_img.set_estimates({{0, 2}, {0, 2048}, {0, 2048}});
+            delta_r.set_estimate(0.539505);
+            N_fft.set_estimate(4096);
+            taylor_s_l.set_estimate(30);
         } else if(tgt.has_gpu_feature()) {
             // GPU target
             std::cout << "Scheduling for GPU: " << tgt << std::endl
@@ -310,3 +309,4 @@ private:
 
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda)
+HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_auto_m16)

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -21,6 +21,7 @@
 #include "backprojection_ritsar_s.h"
 #include "backprojection_ritsar_p.h"
 #include "backprojection_ritsar_vp.h"
+#include "backprojection_auto_m16.h"
 #include "img_output_u8.h"
 #include "img_output_to_dB.h"
 
@@ -128,6 +129,9 @@ int main(int argc, char **argv) {
     } else if (bp_sched == "ritsar-vp") {
         backprojection_impl = backprojection_ritsar_vp;
         cout << "Using RITSAR baseline (vectorize+parallel)" << endl;
+    } else if (bp_sched == "auto-m16") {
+        backprojection_impl = backprojection_auto_m16;
+        cout << "Using autoschedule (Mullapudi2016)" << endl;
     } else {
         cerr << "Unknown schedule: " << bp_sched << endl;
         return -1;


### PR DESCRIPTION
Only Mullapudi2016 for now, as that's the only one that works so far.

It runs with the "auto-m16" parameter.  This naming scheme leaves room for more autoscheduler targets in the future.

This autoscheduler generates some warnings as it works, I don't know how to turn these off.

```
Warning: Insufficient parallelism for fftshift
Warning: Outer dim vectorization of var "pulse" in function "sum$1"
Warning: Outer dim vectorization of var "pulse" in function "sum$1.update(0)"
Warning: Outer dim vectorization of var "pulse" in function "sum.update(0)"
Warning: Insufficient parallelism for win_pulse_F_m
Warning: Insufficient parallelism for win_pulse_F_m_den
Warning: Outer dim vectorization of var "pulse" in function "win_pulse_F_m_den.update(0)"
Warning: Insufficient parallelism for win_pulse_F_m_den.update(0)
Warning: Insufficient parallelism for win_pulse_F_m_num
Warning: Outer dim vectorization of var "pulse" in function "win_pulse_F_m_num.update(0)"
Warning: Insufficient parallelism for win_pulse_F_m_num.update(0)
Warning: Insufficient parallelism for win_pulse_maximum
Warning: Insufficient parallelism for win_pulse_maximum.update(0)
Warning: Outer dim vectorization of var "pulse" in function "win_pulse_w.update(0)"
Warning: Insufficient parallelism for win_sample_F_m
Warning: Insufficient parallelism for win_sample_F_m_den
Warning: Outer dim vectorization of var "sample" in function "win_sample_F_m_den.update(0)"
Warning: Insufficient parallelism for win_sample_F_m_den.update(0)
Warning: Insufficient parallelism for win_sample_F_m_num
Warning: Outer dim vectorization of var "sample" in function "win_sample_F_m_num.update(0)"
Warning: Insufficient parallelism for win_sample_F_m_num.update(0)
Warning: Insufficient parallelism for win_sample_maximum
Warning: Insufficient parallelism for win_sample_maximum.update(0)
Warning: Outer dim vectorization of var "sample" in function "win_sample_w.update(0)"
```
