### PR TITLE
ImgPlane: move inline funcs to header

### DIFF
--- a/ImgPlane.cpp
+++ b/ImgPlane.cpp
@@ -3,6 +3,7 @@
 #include <Halide.h>
 
 #include "ImgPlane.h"
+#include "ip.h"
 
 // Halide generators
 #include "ip_uv.h"
@@ -13,20 +14,6 @@
 
 using namespace std;
 using Halide::Runtime::Buffer;
-
-inline double ip_upsample(int n) {
-    double l = log2((double) n);
-    int r = (l - (int)l) > 0;
-    return pow(2, (int)(l + r));
-}
-
-inline double ip_du(double delta_r, double res_factor, int nsamples, int nu) {
-    return delta_r * res_factor * nsamples / nu;
-}
-
-inline double ip_dv(double aspect, double du) {
-    return aspect * du;
-}
 
 ImgPlane img_plane_create(PlatformData &pd, double res_factor,
                           const float *_n_hat, double aspect, bool upsample) {

--- a/ip.h
+++ b/ip.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cmath>
+
+inline double ip_upsample(int n) {
+    double l = log2((double) n);
+    int r = (l - (int)l) > 0;
+    return pow(2, (int)(l + r));
+}
+
+inline double ip_du(double delta_r, double res_factor, int nsamples, int nu) {
+    return delta_r * res_factor * nsamples / nu;
+}
+
+inline double ip_dv(double aspect, double du) {
+    return aspect * du;
+}
+


### PR DESCRIPTION
Will be called by CASPER implementation.