### PR TITLE
factor dft code out of sarbp.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ target_link_libraries(img_output_u8_test PRIVATE Halide::Halide
                                                  ${CNPY}
                                                  img_output_u8)
 
-add_executable(sarbp_test sarbp.cpp PlatformData.cpp ImgPlane.cpp)
+add_executable(sarbp_test sarbp.cpp dft.cpp PlatformData.cpp ImgPlane.cpp)
 target_compile_options(sarbp_test PRIVATE $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O2>)
 target_include_directories(sarbp_test PRIVATE ${CNPY_INCLUDE_DIR}
                                               ${ZLIB_INCLUDE_DIRS}

--- a/dft.cpp
+++ b/dft.cpp
@@ -1,0 +1,76 @@
+#include "dft.h"
+
+#include <Halide.h>
+#include <fftw3.h>
+
+#include <cassert>
+#include <iostream>
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+using namespace std;
+
+// FFTW plan initialization can have high overhead, so share and reuse it
+static fftw_plan fft_plan = nullptr;
+
+void dft_init_fftw(size_t N_fft) {
+    assert(N_fft > 0);
+    fftw_complex *fft_in = fftw_alloc_complex(N_fft);
+    assert(fft_in);
+    fftw_complex *fft_out = fftw_alloc_complex(N_fft);
+    assert(fft_out);
+    fft_plan = fftw_plan_dft_1d(N_fft, fft_in, fft_out, FFTW_FORWARD, FFTW_ESTIMATE);
+    assert(fft_plan);
+    fftw_free(fft_in);
+    fftw_free(fft_out);
+}
+
+void dft_destroy_fftw(void) {
+    fftw_destroy_plan(fft_plan);
+    fft_plan = nullptr;
+}
+
+int call_dft(halide_buffer_t *in, int N_fft, halide_buffer_t *out) {
+    // input and output are complex data
+    assert(in->dimensions == 3);
+    assert(out->dimensions == 3);
+    assert(out->dim[0].min == 0);
+    assert(out->dim[0].extent == 2);
+    // FFTW needs entire rows of complex data
+    assert(out->dim[1].min == 0);
+    assert(out->dim[1].extent == N_fft);
+    if(in->is_bounds_query()) {
+#if 0
+        cout << "call_dft: bounds query" << endl;
+#endif
+        // input and output shapes are the same
+        for (int i = 0; i < in->dimensions; i++) {
+            in->dim[i].min = out->dim[i].min;
+            in->dim[i].extent = out->dim[i].extent;
+        }
+    } else {
+        assert(in->host);
+        assert(in->type == halide_type_of<double>());
+        assert(out->host);
+        assert(fft_plan);
+#if 0
+        cout << "call_dft: FFTW: processing vectors ["
+             << out->dim[2].min << ", " << out->dim[2].min + out->dim[2].extent << ")" << endl;
+#endif
+        for (int i = out->dim[2].min; i < out->dim[2].min + out->dim[2].extent; i++) {
+            int coords[3] = {0, 0, i};
+            fftw_complex *fft_in = (fftw_complex *)in->address_of(coords);
+            fftw_complex *fft_out = (fftw_complex *)out->address_of(coords);
+            fftw_execute_dft(fft_plan, fft_in, fft_out);
+        }
+#if 0
+        cout << "call_dft: FFTW: finished" << endl;
+#endif
+    }
+    return 0;
+}
+

--- a/dft.cpp
+++ b/dft.cpp
@@ -34,6 +34,9 @@ void dft_destroy_fftw(void) {
     fft_plan = nullptr;
 }
 
+#ifdef NO_MANGLE
+extern "C" DLLEXPORT
+#endif
 int call_dft(halide_buffer_t *in, int N_fft, halide_buffer_t *out) {
     // input and output are complex data
     assert(in->dimensions == 3);

--- a/dft.h
+++ b/dft.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <unistd.h>
+
+void dft_init_fftw(size_t N_fft);
+void dft_destroy_fftw(void);

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -8,8 +8,8 @@
 #include <halide_image_io.h>
 
 #include <cnpy.h>
-#include <fftw3.h>
 
+#include "dft.h"
 #include "PlatformData.h"
 #include "ImgPlane.h"
 
@@ -31,66 +31,6 @@ using Halide::Runtime::Buffer;
 // local to this file
 #define DEBUG_BP 0
 #define DEBUG_BP_DB 0
-
-// FFTW plan initialization can have high overhead, so share and reuse it
-static fftw_plan fft_plan = nullptr;
-
-static void ctx_init_fftw(size_t N_fft) {
-    assert(N_fft > 0);
-    fftw_complex *fft_in = fftw_alloc_complex(N_fft);
-    assert(fft_in);
-    fftw_complex *fft_out = fftw_alloc_complex(N_fft);
-    assert(fft_out);
-    fft_plan = fftw_plan_dft_1d(N_fft, fft_in, fft_out, FFTW_FORWARD, FFTW_ESTIMATE);
-    assert(fft_plan);
-    fftw_free(fft_in);
-    fftw_free(fft_out);
-}
-
-static void ctx_destroy_fftw(void) {
-    fftw_destroy_plan(fft_plan);
-    fft_plan = nullptr;
-}
-
-int call_dft(halide_buffer_t *in, int N_fft, halide_buffer_t *out) {
-    // input and output are complex data
-    assert(in->dimensions == 3);
-    assert(out->dimensions == 3);
-    assert(out->dim[0].min == 0);
-    assert(out->dim[0].extent == 2);
-    // FFTW needs entire rows of complex data
-    assert(out->dim[1].min == 0);
-    assert(out->dim[1].extent == N_fft);
-    if(in->is_bounds_query()) {
-#if 0
-        cout << "call_dft: bounds query" << endl;
-#endif
-        // input and output shapes are the same
-        for (int i = 0; i < in->dimensions; i++) {
-            in->dim[i].min = out->dim[i].min;
-            in->dim[i].extent = out->dim[i].extent;
-        }
-    } else {
-        assert(in->host);
-        assert(in->type == halide_type_of<double>());
-        assert(out->host);
-        assert(fft_plan);
-#if 0
-        cout << "call_dft: FFTW: processing vectors ["
-             << out->dim[2].min << ", " << out->dim[2].min + out->dim[2].extent << ")" << endl;
-#endif
-        for (int i = out->dim[2].min; i < out->dim[2].min + out->dim[2].extent; i++) {
-            int coords[3] = {0, 0, i};
-            fftw_complex *fft_in = (fftw_complex *)in->address_of(coords);
-            fftw_complex *fft_out = (fftw_complex *)out->address_of(coords);
-            fftw_execute_dft(fft_plan, fft_in, fft_out);
-        }
-#if 0
-        cout << "call_dft: FFTW: finished" << endl;
-#endif
-    }
-    return 0;
-}
 
 int main(int argc, char **argv) {
     if (argc < 7) {
@@ -154,7 +94,7 @@ int main(int argc, char **argv) {
     int N_fft = static_cast<int>(pow(2, static_cast<int>(log2(pd.nsamples * upsample)) + 1));
 
     // FFTW: init shared context
-    ctx_init_fftw(static_cast<size_t>(N_fft));
+    dft_init_fftw(static_cast<size_t>(N_fft));
 
     // backprojection - pre-FFT
 #if DEBUG_WIN
@@ -275,7 +215,7 @@ int main(int argc, char **argv) {
     }
 
     // FFTW: clean up shared context
-    ctx_destroy_fftw();
+    dft_destroy_fftw();
 
     // write debug output
 #if DEBUG_WIN


### PR DESCRIPTION
Needed for CASPER implementation of the app. Harmless for default implementation.

```
commit e89c1c133615318718c6c0db1415cbf622e6adc0 (HEAD -> PR--factor-dft, origin/PR--factor-dft)
    dft: option to not mangle funcs

    Until CASPER compiler supports controlling the demangling
    feature of Halide when it invokes the generators.

commit a45652e9c0cdcffdad50888c4d01658f4a558098
    dft: factor further

    Needed to resolve some linking issues with the CASPER implementation of
    the app.

commit cdce62e6be2095274371d09c7ed539b70ed80f54
    factor DFT into separate file

    To be linked into the CASPER app, which does not include sarbp.cpp.
 ```