### PR TITLE
Distributed API and scheduling updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ add_halide_library(backprojection_cuda FROM backprojection.generator
                                                 large_buffers
                                                 cuda
                                        PARAMS blocksize=1024)
+add_halide_library(backprojection_auto_m16 FROM backprojection.generator
+                                           FEATURES c_plus_plus_name_mangling
+                                                    large_buffers
+                                           AUTOSCHEDULER Halide::Mullapudi2016)
 add_halide_library(backprojection_distributed FROM backprojection.generator
                                               FEATURES c_plus_plus_name_mangling
                                                        large_buffers
@@ -114,5 +118,6 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
                                     backprojection_ritsar_s
                                     backprojection_ritsar_p
                                     backprojection_ritsar_vp
+                                    backprojection_auto_m16
                                     img_output_u8
                                     img_output_to_dB)

--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -25,7 +25,7 @@ public:
     Input<Buffer<double>> u {"u", 1};
     Input<Buffer<double>> v {"v", 1};
     Input<Buffer<float>> pos {"pos", 2};
-    Input<Buffer<double>> r {"r", 2};
+    Input<Buffer<double>> r_in {"r", 2};
 
 #if DEBUG_WIN
     Output<Buffer<double>> out_win{"out_win", 2};
@@ -107,6 +107,9 @@ public:
         Expr nd = pos.dim(0).extent(); // nd = 3 (spatial dimensions)
         rnpulses = RDom(0, npulses, "rnpulses");
         rnd = RDom(0, nd, "rnd");
+
+        // Boundary conditions
+        r = BoundaryConditions::constant_exterior(r_in, Expr(0.0));
 
         // Create window: produces shape {nsamples, npulses}
         win_sample(sample) = taylor(nsamples, taylor_s_l, sample, "win_sample");
@@ -314,6 +317,7 @@ private:
     Func rr0{"rr0"};
     Func norm_rr0{"norm_rr0"};
     Func dr_i{"dr_i"};
+    Func r{"r"};
     ComplexFunc Q_hat{c, "Q_hat"};
     ComplexFunc img{c, "img"};
     ComplexFunc fimg{c, "fimg"};

--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -219,17 +219,16 @@ public:
         Target tgt(target);
         if(auto_schedule) {
             std::cout << "setting size/scalar estimates for autoscheduler" << std::endl;
-            phs.set_estimates({{0, 2}, {0, 424}, {0, 469}});
-            k_r.set_estimates({{0, 424}});
-            u.set_estimates({{0, 512}});
-            v.set_estimates({{0, 512}});
-            pos.set_estimates({{0, 3}, {0, 469}});
-            r.set_estimates({{0, 262144}, {0, 3}});
-            output_img.set_estimates({{0, 2}, {0, 512}, {0, 512}});
-            delta_r.set_estimate(0.240851);
-            N_fft.set_estimate(1024);
-            taylor_s_l.set_estimate(17);
-            fftsh.inner.compute_root(); // helps the Mullapudi2016 autoscheduler pass full vectors of input to DFT
+            phs.set_estimates({{0, 2}, {0, 1800}, {0, 1999}});
+            k_r.set_estimates({{0, 1800}});
+            u.set_estimates({{0, 2048}});
+            v.set_estimates({{0, 2048}});
+            pos.set_estimates({{0, 3}, {0, 1999}});
+            r_in.set_estimates({{0, 4194304}, {0, 3}});
+            output_img.set_estimates({{0, 2}, {0, 2048}, {0, 2048}});
+            delta_r.set_estimate(0.539505);
+            N_fft.set_estimate(4096);
+            taylor_s_l.set_estimate(30);
         } else if(tgt.has_gpu_feature()) {
             // GPU target
             std::cout << "Scheduling for GPU: " << tgt << std::endl
@@ -328,3 +327,4 @@ private:
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_distributed)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda)
+HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_auto_m16)

--- a/dft.cpp
+++ b/dft.cpp
@@ -64,7 +64,8 @@ int call_dft(halide_buffer_t *in, int N_fft, halide_buffer_t *out) {
         cout << "call_dft: FFTW: processing vectors ["
              << out->dim[2].min << ", " << out->dim[2].min + out->dim[2].extent << ")" << endl;
 #endif
-        for (int i = out->dim[2].min; i < out->dim[2].min + out->dim[2].extent; i++) {
+        int upper_bound = min(in->dim[2].min + in->dim[2].extent, out->dim[2].min + out->dim[2].extent);
+        for (int i = out->dim[2].min; i < upper_bound; i++) {
             int coords[3] = {0, 0, i};
             fftw_complex *fft_in = (fftw_complex *)in->address_of(coords);
             fftw_complex *fft_out = (fftw_complex *)out->address_of(coords);
@@ -76,4 +77,3 @@ int call_dft(halide_buffer_t *in, int N_fft, halide_buffer_t *out) {
     }
     return 0;
 }
-

--- a/img_output.cpp
+++ b/img_output.cpp
@@ -9,24 +9,21 @@ using namespace Halide::Tools;
 
 class ImgOutputToDBGenerator : public Halide::Generator<ImgOutputToDBGenerator> {
 public:
-    Input<Buffer<double>> img {"img", 2}; // complex input
-    Input<int> nu{"nu"}, nv{"nv"};
+    Input<Buffer<double>> img {"img", 3}; // complex input
     Output<Buffer<double>> out{"out", 2};
 
     void generate() {
-        Var pixel{"pixel"};
         Var x{"x"}, y{"y"}, c{"c"};
 
         Func img_func("cimg");
         img_func = img;
         ComplexFunc cimg(c, img_func);
 
-        RDom r(0, img.dim(1).extent(), "r");
+        RDom r(0, img.dim(1).extent(), 0, img.dim(2).extent(), "r");
         Func m("m");
-        m() = maximum(abs(cimg(r.x)));
+        m() = maximum(abs(cimg(r.x, r.y)));
 
-        // output: produce shape {nu, nv}, but reverse row order
-        out(x, y) = Expr(10) * log10(abs(cimg((nu * (nv - y - 1)) + x)) / m());
+        out(x, y) = Expr(10) * log10(abs(cimg(x, y)) / m());
 
         m.compute_root();
     }

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -284,14 +284,14 @@ int main(int argc, char **argv) {
     Buffer<double, 2> buf_fimg(2, ip.u.dim(0).extent() * ip.v.dim(0).extent());
 #endif
 
-    Buffer<double, 2> buf_bp(nullptr, {2, ip.u.dim(0).extent() * ip.v.dim(0).extent()});
+    Buffer<double, 2> buf_bp(nullptr, {2, ip.u.dim(0).extent(), ip.v.dim(0).extent()});
     if (is_distributed) {
-        buf_bp.set_distributed({2, ip.u.dim(0).extent() * ip.v.dim(0).extent()});
+        buf_bp.set_distributed({2, ip.u.dim(0).extent(), ip.v.dim(0).extent()});
         // Query local buffer size
         backprojection_impl(pd.phs, pd.k_r, taylor, N_fft, pd.delta_r, ip.u, ip.v, pd.pos, ip.pixel_locs, buf_bp);
         buf_bp.allocate();
     } else {
-        buf_bp = Buffer<double, 2>(2, ip.u.dim(0).extent() * ip.v.dim(0).extent());
+        buf_bp = Buffer<double, 3>(2, ip.u.dim(0).extent(), ip.v.dim(0).extent());
     }
     cout << "Halide backprojection start " << endl;
     start = high_resolution_clock::now();
@@ -357,9 +357,9 @@ int main(int argc, char **argv) {
         // Send data to rank 0
         buf_bp.copy_to_host();
         if (rank == 0) {
-            buf_bp_full = Buffer<double, 2>(2, ip.u.dim(0).extent() * ip.v.dim(0).extent());
+            buf_bp_full = Buffer<double, 3>(2, ip.u.dim(0).extent(), ip.v.dim(0).extent());
             // Copy buf_bp to buf_bp_full
-            memcpy(buf_bp_full.data(), buf_bp.data(), sizeof(double) * buf_bp.dim(1).extent() * 2);
+            memcpy(buf_bp_full.data(), buf_bp.data(), sizeof(double) * buf_bp.dim(1).extent() * buf_bp.dim(2).extent() * 2);
             for (int r = 1; r < numprocs; r++) {
                 // Obtain the min & extent from the node
                 int r_min = 0, r_extent = 0;
@@ -373,7 +373,7 @@ int main(int argc, char **argv) {
                          r, 2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
             }
         } else {
-            int r_min = buf_bp.dim(1).min(), r_extent = buf_bp.dim(1).extent();
+            int r_min = buf_bp.dim(2).min() * buf_bp.dim(1).extent(), r_extent = buf_bp.dim(2).extent() * buf_bp.dim(1).extent();
             MPI_Send(&r_min, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
             MPI_Send(&r_extent, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
             // Sending the actual content
@@ -475,7 +475,7 @@ int main(int argc, char **argv) {
         Buffer<double, 2> buf_bp_dB(ip.u.dim(0).extent(), ip.v.dim(0).extent());
         cout << "Halide dB conversion start" << endl;
         start = high_resolution_clock::now();
-        rv = img_output_to_dB(buf_bp_full, buf_bp_dB.width(), buf_bp_dB.height(), buf_bp_dB);
+        rv = img_output_to_dB(buf_bp_full, buf_bp_dB);
         stop = high_resolution_clock::now();
         cout << "Halide dB conversion returned " << rv << " in "
              << duration_cast<milliseconds>(stop - start).count() << " ms" << endl;

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -25,6 +25,7 @@
 #include "backprojection_ritsar_s.h"
 #include "backprojection_ritsar_p.h"
 #include "backprojection_ritsar_vp.h"
+#include "backprojection_auto_m16.h"
 #include "img_output_u8.h"
 #include "img_output_to_dB.h"
 
@@ -190,6 +191,9 @@ int main(int argc, char **argv) {
     } else if (bp_sched == "ritsar-vp") {
         backprojection_impl = backprojection_ritsar_vp;
         cout << "Using RITSAR baseline (vectorize+parallel)" << endl;
+    } else if (bp_sched == "auto-m16") {
+        backprojection_impl = backprojection_auto_m16;
+        cout << "Using CPU autoschedule (Mullapudi2016)" << endl;
     } else {
         cerr << "Unknown schedule: " << bp_sched << endl;
         print_usage(argv[0], cerr);


### PR DESCRIPTION
* Bring the backprojection() calling conventions back in line with the ritsar implementation
* Update the MPI image reduction to operate on the 2D+complex image array
* Add an option to run the Mullapudi2016 autoscheduler
* Fix a couple of bugs uncovered by the autoscheduler
* Update the CPU schedule, following advice from the autoscheduler