### PR TITLE
Redo gpu schedule to allow distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,12 @@ add_halide_library(backprojection_cuda FROM backprojection.generator
                                        FEATURES c_plus_plus_name_mangling
                                                 large_buffers
                                                 cuda
-                                       PARAMS blocksize=1024)
+                                       PARAMS blocksize=16)
+add_halide_library(backprojection_cuda_distributed FROM backprojection.generator
+                                       FEATURES c_plus_plus_name_mangling
+                                                large_buffers
+                                                cuda
+                                       PARAMS blocksize=16 is_distributed=true)
 add_halide_library(backprojection_auto_m16 FROM backprojection.generator
                                            FEATURES c_plus_plus_name_mangling
                                                     large_buffers
@@ -117,6 +122,7 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
                                     backprojection
                                     backprojection_distributed
                                     backprojection_cuda
+                                    backprojection_cuda_distributed
                                     backprojection_ritsar
                                     backprojection_ritsar_s
                                     backprojection_ritsar_p

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -21,6 +21,7 @@
 #include "backprojection.h"
 #include "backprojection_distributed.h"
 #include "backprojection_cuda.h"
+#include "backprojection_cuda_distributed.h"
 #include "backprojection_ritsar.h"
 #include "backprojection_ritsar_s.h"
 #include "backprojection_ritsar_p.h"
@@ -176,6 +177,10 @@ int main(int argc, char **argv) {
         backprojection_impl = backprojection_distributed;
         is_distributed = true;
         cout << "Using schedule for distributed CPU" << endl;
+    } else if (bp_sched == "cuda_distributed") {
+        backprojection_impl = backprojection_cuda_distributed;
+        is_distributed = true;
+        cout << "Using schedule for distributed CUDA" << endl;
     } else if (bp_sched == "cuda") {
         backprojection_impl = backprojection_cuda;
         cout << "Using schedule with CUDA" << endl;


### PR DESCRIPTION
Scheduling improvements:
* Distribute `fimg` and `output_img`
* Use GPU to compute `norm_r0` and `fimg`
* Everything after `norm_r0`, from `rr0` onward is computed as part of `fimg`
* Add `cuda_distributed` schedule to `sarbp`

Fixes to enable the above:
* Use x,y indexing for `fimg`
* Tune `blocksize` to allow warp usage
* Wrap `pos` input in a boundary condition

The `fimg` function uses x,y indexing to allow distributing `fimg`.  The vector-indexed style is a big vector containing rows of image data, starting with the bottom-most row and going up toward the top.  Splitting over this would result in compute node 0 processing a stripe at the bottom of the image, not the top.  This is the opposite of how `output_img` is distributed.  I made the indexing system consistent so that the distribution would also be consistent.

Note that I also tried to use the GPU to compute `Q`, but that causes a segfault in libfftw.  I suspect Halide is allocating `dft`'s output (`Q`'s input) in GPU memory, not on the host.

The `blocksize` tweak fixes this error:
```
Unhandled exception: Error: CUDA gpu lanes loop must have constant extent of at most 32: 1024
```

The boundary condition on `pos` fixes this error:

```
Halide backprojection start 
Error: Input buffer pos is accessed at 1999, which is beyond the max (1998) in dimension 1
Aborted (core dumped)
```
