### PR TITLE
win_pulse and win_sample scheduling

### DIFF
--- a/backprojection_ritsar.cpp
+++ b/backprojection_ritsar.cpp
@@ -66,9 +66,9 @@ public:
         RDom rnd(0, nd, "rnd");
 
         // Create window: produces shape {nsamples, npulses}
-        win_x(x) = taylor(nsamples, taylor_s_l, x, "win_x");
-        win_y(y) = taylor(npulses, taylor_s_l, y, "win_y");
-        win(x, y) = win_x(x) * win_y(y);
+        win_x = Taylor(nsamples, taylor_s_l, x, "win_x");
+        win_y = Taylor(npulses, taylor_s_l, y, "win_y");
+        win(x, y) = win_x.taylor(x) * win_y.taylor(y);
 
         // Filter phase history: produces shape {nsamples}
         filt(x) = abs(k_r(x));
@@ -127,8 +127,8 @@ public:
     void schedule() {
         switch (sched) {
         case Schedule::Serial:
-            win_x.compute_root();
-            win_y.compute_root();
+            win_x.taylor.compute_root();
+            win_y.taylor.compute_root();
             win.compute_root();
             filt.compute_root();
             phs_filt.inner.compute_root();
@@ -148,8 +148,8 @@ public:
             output_img.compute_root();
             break;
         case Schedule::Vectorize:
-            win_x.compute_root().vectorize(x, vectorsize);
-            win_y.compute_root().vectorize(y, vectorsize);
+            win_x.taylor.compute_root().vectorize(x, vectorsize);
+            win_y.taylor.compute_root().vectorize(y, vectorsize);
             win.compute_root().vectorize(x, vectorsize);
             filt.compute_root().vectorize(x, vectorsize);
             phs_filt.inner.compute_root().vectorize(x, vectorsize);
@@ -171,8 +171,8 @@ public:
             break;
         case Schedule::Parallel:
             // TODO: can win_x and win_y be parallelized?
-            win_x.compute_root();
-            win_y.compute_root();
+            win_x.taylor.compute_root();
+            win_y.taylor.compute_root();
             win.compute_root().parallel(y);
             filt.compute_root().parallel(x);
             phs_filt.inner.compute_root().parallel(y);
@@ -194,8 +194,8 @@ public:
             break;
         case Schedule::VectorizeParallel:
             // TODO: can win_x and win_y be parallelized?
-            win_x.compute_root().vectorize(x, vectorsize);
-            win_y.compute_root().vectorize(y, vectorsize);
+            win_x.taylor.compute_root().vectorize(x, vectorsize);
+            win_y.taylor.compute_root().vectorize(y, vectorsize);
             win.compute_root().vectorize(x, vectorsize).parallel(y);
             filt.compute_root().vectorize(x, vectorsize).parallel(x);
             phs_filt.inner.compute_root().vectorize(x, vectorsize).parallel(y);
@@ -222,8 +222,8 @@ public:
 private:
     Var c{"c"}, x{"x"}, y{"y"}, z{"z"};
 
-    Func win_x{"win_x"};
-    Func win_y{"win_y"};
+    Taylor win_x;
+    Taylor win_y;
     Func win{"win"};
     Func filt{"filt"};
     ComplexFunc phs_filt{c, "phs_filt"};

--- a/signal.h
+++ b/signal.h
@@ -11,32 +11,44 @@ using namespace Halide;
 #define M_PI 3.14159265358979323846
 #endif
 
-inline Expr taylor(Expr num, Expr S_L, Var x, const std::string &inner_name_prefix = "taylor") {
+class Taylor {
+public:
+    RDom n;
+    RDom r;
+    Func taylor;
+    Func w;
+    Func F_m;
+    Func F_m_num;
+    Func F_m_den;
+    Taylor(Expr num, Expr S_L, Var x, const std::string &inner_name_prefix = "taylor") {
     // need to define our domain
-    RDom n(0, num, "n");
+        n = RDom(0, num, "n");
 
-    Expr xi = linspace(Expr(-0.5), Expr(0.5), num, x);
-    Expr A = Expr(1.0 / (double)M_PI) * acosh(pow(10, S_L * Expr(1.0/20)));
-    Expr n_bar = ConciseCasts::i32(2 * pow(A, 2) + Expr(0.5)) + Expr(1);
-    Expr sigma_p = n_bar / sqrt(pow(A, 2) + (pow(n_bar - Expr(0.5), 2)));
+        Expr xi = linspace(Expr(-0.5), Expr(0.5), num, x);
+        Expr A = Expr(1.0 / (double)M_PI) * acosh(pow(10, S_L * Expr(1.0/20)));
+        Expr n_bar = ConciseCasts::i32(2 * pow(A, 2) + Expr(0.5)) + Expr(1);
+        Expr sigma_p = n_bar / sqrt(pow(A, 2) + (pow(n_bar - Expr(0.5), 2)));
 
-    Func F_m_num(inner_name_prefix + "_F_m_num");
-    Func F_m_den(inner_name_prefix + "_F_m_den");
-    Func F_m(inner_name_prefix + "_F_m");
-    RDom r = RDom(0, n_bar - 1, inner_name_prefix + "_r");
-    F_m_num(x) = Expr(1.0);
-    F_m_den(x) = Expr(1.0);
-    F_m_num(x) *= pow(-1, x + 2) * (Expr(1.0) - pow(x + 1, 2) / pow(sigma_p, 2) / (pow(A, 2) + pow(r.x + Expr(0.5), 2)));
-    F_m_den(x) = select(x == r.x, F_m_den(x), F_m_den(x) * (Expr(1.0) - pow(x + 1, 2) / pow(r.x + 1, 2)));
-    F_m(x) = F_m_num(x) / F_m_den(x);
+        taylor = Func(inner_name_prefix);
+        F_m_num = Func(inner_name_prefix + "_F_m_num");
+        F_m_den = Func(inner_name_prefix + "_F_m_den");
+        F_m = Func(inner_name_prefix + "_F_m");
+        r = RDom(0, n_bar - 1, inner_name_prefix + "_r");
+        F_m_num(x) = Expr(1.0);
+        F_m_den(x) = Expr(1.0);
+        F_m_num(x) *= pow(-1, x + 2) * (Expr(1.0) - pow(x + 1, 2) / pow(sigma_p, 2) / (pow(A, 2) + pow(r.x + Expr(0.5), 2)));
+        F_m_den(x) = select(x == r.x, F_m_den(x), F_m_den(x) * (Expr(1.0) - pow(x + 1, 2) / pow(r.x + 1, 2)));
+        F_m(x) = F_m_num(x) / F_m_den(x);
 
-    Func w(inner_name_prefix + "_w");
-    w(x) = Expr(1.0);
-    w(x) += F_m(r) * cos(Expr(2 * (double)M_PI) * (r + 1) * xi);
+        w = Func(inner_name_prefix + "_w");
+        w(x) = Expr(1.0);
+        w(x) += F_m(r) * cos(Expr(2 * (double)M_PI) * (r + 1) * xi);
 
-    // separate iteration domain (RDom) to get maximum
-    return w(x) / maximum(w(n), inner_name_prefix + "_maximum");
-}
+        // separate iteration domain (RDom) to get maximum
+        taylor(x) = w(x) / maximum(w(n), inner_name_prefix + "_maximum");
+    }
+    Taylor() {}
+};
 
 // Normalizes dB between 0 and 1, then scales by Type t's max (e.g., UInt(8) or UInt(16))
 // Return type depends on dB, but can then be safely cast to Type t

--- a/test/taylor.cpp
+++ b/test/taylor.cpp
@@ -12,7 +12,8 @@ public:
 
     void generate() {
         Var x{"x"};
-        output(x) = taylor(nsamples, S_L, x);
+        Taylor taylor(nsamples, S_L, x);
+        output(x) = taylor.taylor(x);
     }
 };
 


### PR DESCRIPTION
Turns `taylor()` into a `Taylor` class that holds the inner Funcs for later scheduling.
Add scheduling directives based on the autoscheduler.

Before (Sandia dataset, CUDA, single node):
```
Halide backprojection start 
Halide backprojection returned 0 in 4558 ms
Halide dB conversion start
Halide dB conversion returned 0 in 14 ms
Halide PNG production start
Halide PNG production returned 0 in 6 ms
Wrote Sandia-cuda.png in 173 ms
backprojection_cuda
 total time: 4557.712402 ms  samples: 4302  runs: 1  time/run: 4557.712402 ms
 average threads used: 3.274291
 heap allocations: 986  peak heap usage: 262012928 bytes
  overhead:              88.010ms  (1%)    threads: 0.000 
  norm_r0:               0.000ms   (0%)    threads: 0.000 
  filt:                  0.000ms   (0%)    threads: 0.000  peak: 7200     num: 1         avg: 7200
  win_pulse:             0.000ms   (0%)    threads: 0.000  peak: 15992    num: 1         avg: 15992
  win_pulse_maximum:     1.057ms   (0%)    threads: 20.000 stack: 32
  win_pulse_w:           169.501ms (3%)    threads: 25.031 peak: 1791104  num: 512       avg: 63968 stack: 32
  win_pulse_F_m_num:     1.057ms   (0%)    threads: 24.000 stack: 32
  win_pulse_F_m_den:     15.909ms  (0%)    threads: 21.133 stack: 32
  win_sample:            0.000ms   (0%)    threads: 0.000  peak: 14400    num: 1         avg: 14400
  win_sample_maximum:    2.114ms   (0%)    threads: 19.000 stack: 32
  win_sample_w:          144.236ms (3%)    threads: 23.352 peak: 1670400  num: 464       avg: 57600 stack: 32
  win_sample_F_m_num:    1.063ms   (0%)    threads: 29.000 stack: 32
  win_sample_F_m_den:    25.411ms  (0%)    threads: 15.833 stack: 32
  win:                   8.460ms   (0%)    threads: 1.000  peak: 28785600 num: 1         avg: 28785600
  phs_filt:              19.057ms  (0%)    threads: 1.000  peak: 57571200 num: 1         avg: 57571200
  phs_pad:               13.790ms  (0%)    threads: 15.750 peak: 131006464 num: 1        avg: 131006464
  fftshift:              19.363ms  (0%)    threads: 24.777 peak: 131006464 num: 1        avg: 131006464
  dft:                   26.679ms  (0%)    threads: 36.680 peak: 131006464 num: 1        avg: 131006464
  Q:                     24.392ms  (0%)    threads: 32.434 peak: 131006464 num: 1        avg: 131006464
  fimg:                  33.884ms  (0%)    threads: 1.000  peak: 67108864 num: 1         avg: 67108864
  norm_rr0:              0.000ms   (0%)    threads: 0.000  stack: 8
  output_img:            3963.722ms(86%)   threads: 1.015 
```

After:
```
Halide backprojection start 
Halide backprojection returned 0 in 4243 ms
Halide dB conversion start
Halide dB conversion returned 0 in 15 ms
Halide PNG production start
Halide PNG production returned 0 in 6 ms
Wrote Sandia-cuda.png in 170 ms
backprojection_cuda
 total time: 4242.067871 ms  samples: 3974  runs: 1  time/run: 4242.067871 ms
 average threads used: 1.455209
 heap allocations: 12  peak heap usage: 262012928 bytes
  overhead:              88.760ms  (2%)    threads: 0.000 
  norm_r0:               0.000ms   (0%)    threads: 0.000 
  filt:                  0.000ms   (0%)    threads: 0.000  peak: 7200     num: 1         avg: 7200
  win_pulse_w:           3.182ms   (0%)    threads: 0.333  peak: 15992    num: 1         avg: 15992
  win_pulse_F_m_num:     0.000ms   (0%)    threads: 0.000  stack: 32
  win_pulse_F_m_den:     0.000ms   (0%)    threads: 0.000  stack: 32
  win_pulse:             0.000ms   (0%)    threads: 0.000  peak: 15992    num: 1         avg: 15992
  win_pulse_maximum:     1.059ms   (0%)    threads: 4.000  stack: 32
  win_sample_w:          3.171ms   (0%)    threads: 0.000  peak: 14400    num: 1         avg: 14400
  win_sample_F_m_num:    0.000ms   (0%)    threads: 0.000  stack: 32
  win_sample_F_m_den:    0.000ms   (0%)    threads: 0.000  stack: 32
  win_sample:            1.059ms   (0%)    threads: 0.000  peak: 14400    num: 1         avg: 14400
  win_sample_maximum:    0.000ms   (0%)    threads: 0.000  stack: 32
  win:                   10.589ms  (0%)    threads: 1.000  peak: 28785600 num: 1         avg: 28785600
  phs_filt:              25.381ms  (0%)    threads: 1.000  peak: 57571200 num: 1         avg: 57571200
  phs_pad:               16.248ms  (0%)    threads: 10.888 peak: 131006464 num: 1        avg: 131006464
  fftshift:              21.849ms  (0%)    threads: 11.066 peak: 131006464 num: 1        avg: 131006464
  dft:                   30.077ms  (0%)    threads: 32.428 peak: 131006464 num: 1        avg: 131006464
  Q:                     25.496ms  (0%)    threads: 31.250 peak: 131006464 num: 1        avg: 131006464
  fimg:                  41.416ms  (0%)    threads: 1.000  peak: 67108864 num: 1         avg: 67108864
  norm_rr0:              0.000ms   (0%)    threads: 0.000  stack: 8
  output_img:            3973.775ms(93%)   threads: 1.013 
```
