### PR TITLE
Remove blocksize_distributed split on y

### DIFF
--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -246,7 +246,6 @@ public:
             Var sample_vo{"sample_vo"}, sample_vi{"sample_vi"};
             Var pulse_vo{"pulse_vo"}, pulse_vi{"pulse_vi"};
             Var x_vo{"x_vo"}, x_vi{"x_vi"};
-            Var y_vo{"y_vo"}, y_vi{"y_vi"};
             Var pixeli{"pixeli"}, block{"block"};
             win_sample.compute_root()
                       .vectorize(sample, vectorsize)
@@ -290,19 +289,16 @@ public:
                       .bound(c, 0, 2)
                       .unroll(c)
                       .split(x, x_vo, x_vi, blocksize)
-                      .split(y, y_vo, y_vi, blocksize)
-                      .gpu_lanes(x_vi)
-                      .gpu_blocks(y_vo)
-                      .gpu_threads(y_vi);
+                      .gpu_blocks(y)
+                      .gpu_threads(x_vi);
             output_img.compute_root()
                       .bound(c, 0, 2)
                       .unroll(c)
-                      .split(y, y_vo, y_vi, blocksize)
                       .vectorize(x, vectorsize)
-                      .parallel(y_vo, blocksize);
+                      .parallel(y);
             if (is_distributed) {
-                output_img.distribute(y_vo);
-                fimg.inner.distribute(y_vo);
+                output_img.distribute(y);
+                fimg.inner.distribute(y);
             }
             if (print_loop_nest) {
                 output_img.print_loop_nest();
@@ -316,7 +312,6 @@ public:
                 std::cout << "Block size (distributed): " << blocksize_distributed.value() << std::endl;
             }
             Var x_vo{"x_vo"}, x_vi{"x_vi"};
-            Var y_vo{"y_vo"}, y_vi{"y_vi"};
             Var sample_vo{"sample_vo"}, sample_vi{"sample_vi"};
             Var pulse_vo{"pulse_vo"}, pulse_vi{"pulse_vi"};
             win_sample.compute_root()
@@ -370,11 +365,10 @@ public:
             fimg.inner.compute_inline();
             output_img.compute_root()
                       .split(x, x_vo, x_vi, vectorsize)
-                      .split(y, y_vo, y_vi, blocksize_distributed)
                       .vectorize(x_vi)
-                      .parallel(y_vi);
+                      .parallel(y);
             if (is_distributed) {
-                output_img.distribute(y_vo);
+                output_img.distribute(y);
             }
             if (print_loop_nest) {
                 output_img.print_loop_nest();


### PR DESCRIPTION
Remove blocking on the Y axis from CPU and GPU schedules, in an attempt to remove constraints on local parallelism.

CPU performance/scalability seems about the same, in my testing.  (See below)

GPU schedule was simplified a bit more, to remove blocking on the Y axis, and remove my misuse of the `gpu_lanes` directive.  Performance is about 40% slower.  There are further improvements possible here, but it's not a priority.

Distribution pattern should be identical between CPU and GPU.

Here are the CPU runtimes I got from testing with the Sandia dataset, 4 threads per node.

```
before patch:
2 nodes:
Halide backprojection returned 0 in 42765 ms
Halide backprojection returned 0 in 43119 ms
4 nodes:
Halide backprojection returned 0 in 21077 ms
Halide backprojection returned 0 in 21176 ms
Halide backprojection returned 0 in 24639 ms
Halide backprojection returned 0 in 24984 ms
8 nodes:
Halide backprojection returned 0 in 11091 ms
Halide backprojection returned 0 in 11414 ms
Halide backprojection returned 0 in 11608 ms
Halide backprojection returned 0 in 12119 ms
Halide backprojection returned 0 in 12187 ms
Halide backprojection returned 0 in 12281 ms
Halide backprojection returned 0 in 14136 ms
Halide backprojection returned 0 in 14310 ms

after patch:
2 nodes:
Halide backprojection returned 0 in 43549 ms
Halide backprojection returned 0 in 45614 ms
4 nodes:
Halide backprojection returned 0 in 20503 ms
Halide backprojection returned 0 in 20947 ms
Halide backprojection returned 0 in 24490 ms
Halide backprojection returned 0 in 25900 ms
8 nodes:
Halide backprojection returned 0 in 11230 ms
Halide backprojection returned 0 in 11355 ms
Halide backprojection returned 0 in 11506 ms
Halide backprojection returned 0 in 11506 ms
Halide backprojection returned 0 in 12184 ms
Halide backprojection returned 0 in 12421 ms
Halide backprojection returned 0 in 14449 ms
Halide backprojection returned 0 in 16613 ms
```