### PR TITLE
backprojection: add cuda_split schedule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,14 @@ add_halide_library(backprojection_cuda FROM backprojection.generator
                                               blocksize=16
                                               blocksize_gpu_tile=16
                                               blocksize_gpu_split_x=16)
+add_halide_library(backprojection_cuda_split FROM backprojection.generator
+                                       FEATURES c_plus_plus_name_mangling
+                                                large_buffers
+                                                cuda
+                                       PARAMS schedule=gpu-split
+                                              blocksize=16
+                                              blocksize_gpu_tile=16
+                                              blocksize_gpu_split_x=16)
 if(Halide_HAS_DISTRIBUTE)
     add_halide_library(backprojection_distributed FROM backprojection.generator
                                                   FEATURES c_plus_plus_name_mangling
@@ -95,6 +103,14 @@ if(Halide_HAS_DISTRIBUTE)
                                                               blocksize=16
                                                               blocksize_gpu_tile=16
                                                               blocksize_gpu_split_x=16)
+    add_halide_library(backprojection_cuda_split_distributed FROM backprojection.generator
+                                                             FEATURES c_plus_plus_name_mangling
+                                                                      large_buffers
+                                                                      cuda
+                                                             PARAMS schedule=gpu-split-distributed
+                                                                    blocksize=16
+                                                                    blocksize_gpu_tile=16
+                                                                    blocksize_gpu_split_x=16)
 endif()
 add_halide_library(backprojection_auto_m16 FROM backprojection.generator
                                            FEATURES c_plus_plus_name_mangling
@@ -130,6 +146,7 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
                                     ip_pixel_locs
                                     backprojection
                                     backprojection_cuda
+                                    backprojection_cuda_split
                                     backprojection_ritsar
                                     backprojection_ritsar_s
                                     backprojection_ritsar_p
@@ -140,7 +157,8 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
 if(Halide_HAS_DISTRIBUTE)
     target_compile_definitions(sarbp PRIVATE WITH_DISTRIBUTE)
     target_link_libraries(sarbp PRIVATE backprojection_distributed
-                                        backprojection_cuda_distributed)
+                                        backprojection_cuda_distributed
+                                        backprojection_cuda_split_distributed)
 endif()
 if(MPI_FOUND)
     target_compile_definitions(sarbp PRIVATE WITH_MPI)

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -21,9 +21,11 @@
 // Halide generators
 #include "backprojection.h"
 #include "backprojection_cuda.h"
+#include "backprojection_cuda_split.h"
 #if defined(WITH_DISTRIBUTE)
 #include "backprojection_distributed.h"
 #include "backprojection_cuda_distributed.h"
+#include "backprojection_cuda_split_distributed.h"
 #endif // WITH_DISTRIBUTE
 #include "backprojection_ritsar.h"
 #include "backprojection_ritsar_s.h"
@@ -76,7 +78,7 @@ static void print_usage(string prog, ostream& os) {
     os << "  -D, --db-max=REAL       Output image max dB" << endl;
     os << "                          Default: " << DB_MAX_DEFAULT << endl;
     os << "  -s, --schedule=NAME     One of: cpu[_distributed]" << endl;
-    os << "                                  cuda[_distributed]" << endl;
+    os << "                                  cuda[_split][_distributed]" << endl;
     os << "                                  ritsar[-s|-p|-vp]" << endl;
     os << "                                  auto-m16" << endl;
     os << "                          Default: " << SCHED_DEFAULT << endl;
@@ -198,11 +200,23 @@ int main(int argc, char **argv) {
     } else if (bp_sched == "cuda") {
         backprojection_impl = backprojection_cuda;
         cout << "Using schedule with CUDA" << endl;
+    } else if (bp_sched == "cuda_split") {
+        backprojection_impl = backprojection_cuda_split;
+        cout << "Using schedule with CUDA (split output)" << endl;
     } else if (bp_sched == "cuda_distributed") {
 #if defined(WITH_DISTRIBUTE)
         backprojection_impl = backprojection_cuda_distributed;
         is_distributed = true;
         cout << "Using schedule for distributed CUDA" << endl;
+#else
+        cerr << "Distributed schedules require distributed support in Halide" << endl;
+        return EXIT_FAILURE;
+#endif // WITH_DISTRIBUTE
+    } else if (bp_sched == "cuda_split_distributed") {
+#if defined(WITH_DISTRIBUTE)
+        backprojection_impl = backprojection_cuda_split_distributed;
+        is_distributed = true;
+        cout << "Using schedule for distributed CUDA (split output)" << endl;
 #else
         cerr << "Distributed schedules require distributed support in Halide" << endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
This chops up fimg into multiple cuda calls, to reduce GPU memory usage.  This performs slightly worse, but greatly reduces the amount of GPU memory and thus should allow running on larger problem sizes.  The memory reduction comes from storing only a single row of the `fimg` output buffer and the `r` input buffer in GPU memory at once.


Adds both distributed and non-distributed variants.

Performance and memory for `cuda` schedule, from the output of running `sarbp` with Sandia dataset and running `nvidia-smi` in another terminal:

```
Using schedule with CUDA
[...]
(1) Halide backprojection returned 0 in 7552 ms

| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A   2992364      C   ./sarbp                           919MiB |
```

And here's the same for the `cuda_split` schedule:

```
Using schedule with CUDA (split output)
[...]
(1) Halide backprojection returned 0 in 11068 ms

| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A   2992832      C   ./sarbp                           279MiB |
```

The performance is around 40% worse, but it uses 70% less memory according to `nvidia-smi`.  If you get the sizes of the memory buffers in the cuda debug log and add those up, the reduction in data memory usage is closer to 80% (839MB vs 269MB).

I think 20% of the lost performance can be re-gained by being smarter about `norm_r0` and `norm_rr0`.  I will follow up on that in a separate PR.