### PR TITLE
Simplify norm_r0 and norm_rr0 by assuming 3D space.

### DIFF
--- a/util.h
+++ b/util.h
@@ -61,6 +61,18 @@ inline Expr norm(Expr in, const std::string &inner_name_prefix = "norm") {
     return sqrt(sum(in * in, inner_name_prefix + "_sum"));
 }
 
+inline Expr norm3d(Func f, Var x) {
+    return sqrt(f(0, x) * f(0, x)
+              + f(1, x) * f(1, x)
+              + f(2, x) * f(2, x));
+}
+
+inline Expr norm3d(Func f, Var x, Var y) {
+    return sqrt(f(x, 0, y) * f(x, 0, y)
+              + f(x, 1, y) * f(x, 1, y)
+              + f(x, 2, y) * f(x, 2, y));
+}
+
 inline Expr repeat1(Func a, Expr extent_a, Var x) {
     return a(x % extent_a);
 }


### PR DESCRIPTION
* assume physical coordinates exist in 3D space
* remove update definitions in favor of a single expression
* add norm3d_rx and norm3d_xry functions to handle different func param layouts
* remove RDom rnd
* remove scheduling directives for update definitions

This has the following benefits:

* -4 LoC
* easier to read (hopefully)
* less complicated generated code, better performance in cases where dimensionality would be calculated in an inner loop
* easier scheduling

`norm_r0` is small and trivial. `norm_rr0` is a much larger component of our overall performance and memory usage.