### PR TITLE
backprojection cuda schedule that splits execution by pulse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,14 @@ add_halide_library(backprojection_cuda FROM backprojection.generator
                                               blocksize=16
                                               blocksize_gpu_tile=16
                                               blocksize_gpu_split_x=16)
+add_halide_library(backprojection_cuda_split FROM backprojection.generator
+                                             FEATURES c_plus_plus_name_mangling
+                                                      large_buffers
+                                                      cuda
+                                             PARAMS schedule=gpu-split
+                                                    blocksize=16
+                                                    blocksize_gpu_tile=16
+                                                    blocksize_gpu_split_x=16)
 if(Halide_HAS_DISTRIBUTE)
     add_halide_library(backprojection_distributed FROM backprojection.generator
                                                   FEATURES c_plus_plus_name_mangling
@@ -95,6 +103,14 @@ if(Halide_HAS_DISTRIBUTE)
                                                               blocksize=16
                                                               blocksize_gpu_tile=16
                                                               blocksize_gpu_split_x=16)
+    add_halide_library(backprojection_cuda_split_distributed FROM backprojection.generator
+                                                             FEATURES c_plus_plus_name_mangling
+                                                                      large_buffers
+                                                                      cuda
+                                                             PARAMS schedule=gpu-split-distributed
+                                                                    blocksize=16
+                                                                    blocksize_gpu_tile=16
+                                                                    blocksize_gpu_split_x=16)
 endif()
 add_halide_library(backprojection_auto_m16 FROM backprojection.generator
                                            FEATURES c_plus_plus_name_mangling
@@ -130,6 +146,7 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
                                     ip_pixel_locs
                                     backprojection
                                     backprojection_cuda
+                                    backprojection_cuda_split
                                     backprojection_ritsar
                                     backprojection_ritsar_s
                                     backprojection_ritsar_p
@@ -140,7 +157,8 @@ target_link_libraries(sarbp PRIVATE Halide::Halide
 if(Halide_HAS_DISTRIBUTE)
     target_compile_definitions(sarbp PRIVATE WITH_DISTRIBUTE)
     target_link_libraries(sarbp PRIVATE backprojection_distributed
-                                        backprojection_cuda_distributed)
+                                        backprojection_cuda_distributed
+                                        backprojection_cuda_split_distributed)
 endif()
 if(MPI_FOUND)
     target_compile_definitions(sarbp PRIVATE WITH_MPI)

--- a/backprojection.cpp
+++ b/backprojection.cpp
@@ -12,16 +12,20 @@ class BackprojectionGenerator : public Halide::Generator<BackprojectionGenerator
 public:
     enum class Schedule { CPU,
                           GPU,
+                          GPUSplit,
                           CPUDistributed,
                           GPUDistributed,
+                          GPUSplitDistributed,
                         };
     GeneratorParam<Schedule> sched {"schedule",
                                     Schedule::CPU,
                                     {{"cpu", Schedule::CPU},
                                      {"gpu", Schedule::GPU},
+                                     {"gpu-split", Schedule::GPUSplit},
 #if defined(WITH_DISTRIBUTE)
                                      {"cpu-distributed", Schedule::CPUDistributed},
                                      {"gpu-distributed", Schedule::GPUDistributed},
+                                     {"gpu-split-distributed", Schedule::GPUSplitDistributed},
 #endif // WITH_DISTRIBUTE
                                     }
                                    };
@@ -247,6 +251,90 @@ public:
                 output_img.print_loop_nest();
             }
             break;
+        case Schedule::GPUSplit:
+#if defined(WITH_DISTRIBUTE)
+        case Schedule::GPUSplitDistributed:
+#endif // WITH_DISTRIBUTE
+            if (!tgt.has_gpu_feature()) {
+                throw std::runtime_error("GPU schedules require GPU feature");
+            }
+            // GPU target
+            std::cout << "Scheduling for Split GPU: " << tgt << std::endl
+                      << "Vector size: " << vectorsize.value() << std::endl
+                      << "Block size: " << blocksize.value() << std::endl
+                      << "Block size GPU tile: " << blocksize_gpu_tile.value() << std::endl
+                      << "Block size GPU split x: " << blocksize_gpu_split_x.value() << std::endl;
+            win_sample.taylor.compute_root()
+                             .vectorize(sample, vectorsize)
+                             .parallel(sample, blocksize);
+            win_sample.w.compute_root()
+                        .split(sample, sample_vo, sample_vi, vectorsize)
+                        .vectorize(sample_vi)
+                        .parallel(sample_vo);
+            win_sample.w.update(0)
+                        .split(sample, sample_vo, sample_vi, vectorsize, TailStrategy::GuardWithIf)
+                        .vectorize(sample_vi)
+                        .parallel(sample_vo);
+            win_pulse.taylor.compute_root()
+                            .vectorize(pulse, vectorsize)
+                            .parallel(pulse, blocksize);
+            win_pulse.w.compute_root()
+                       .split(pulse, pulse_vo, pulse_vi, vectorsize)
+                       .vectorize(pulse_vi)
+                       .parallel(pulse_vo);
+            win_pulse.w.update(0)
+                       .split(pulse, pulse_vo, pulse_vi, vectorsize, TailStrategy::GuardWithIf)
+                       .vectorize(pulse_vi)
+                       .parallel(pulse_vo);
+            win.compute_root();
+            filt.compute_root();
+            phs_filt.inner.compute_root()
+                          .bound(c, 0, 2).unroll(c)
+                          .vectorize(sample, vectorsize)
+                          .parallel(pulse, blocksize);
+            phs_pad.inner.compute_root()
+                         .bound(c, 0, 2).unroll(c)
+                         .vectorize(sample, vectorsize)
+                         .parallel(pulse, blocksize);
+            fftsh.inner.compute_root()
+                       .bound(c, 0, 2).unroll(c)
+                       .vectorize(sample, vectorsize)
+                       .parallel(pulse, blocksize);
+            dft.inner.compute_root().parallel(pulse);
+            Q.inner.compute_at(img.inner, rnpulses.x)
+                   .store_at(img.inner, rnpulses.x)
+                   .store_in(MemoryType::Heap)
+                   .split(sample, sample_vo, sample_vi, vectorsize)
+                   .vectorize(sample_vi)
+                   .parallel(pulse);
+            norm_r0.compute_root();
+            rr0.compute_inline();
+            norm_rr0.compute_inline();
+            dr_i.compute_inline();
+            Q_hat.inner.compute_inline();
+            img.inner.compute_root()
+                     .gpu_tile(pixel, x_vo, x_vi, blocksize_gpu_tile);
+            img.inner.update(0)
+                     .reorder(c, pixel, rnpulses.x)
+                     .gpu_tile(pixel, x_vo, x_vi, blocksize_gpu_tile);
+            fimg.inner.compute_root()
+                      .reorder(c, x, y)
+                      .gpu_blocks(y)
+                      .gpu_tile(x, x_vo, x_vi, blocksize_gpu_tile);
+            output_img.compute_root()
+                      .bound(c, 0, 2)
+                      .unroll(c)
+                      .vectorize(x, vectorsize)
+                      .parallel(y);
+#if defined(WITH_DISTRIBUTE)
+            if (sched == Schedule::GPUSplitDistributed) {
+                output_img.distribute(y);
+            }
+#endif // WITH_DISTRIBUTE
+            if (print_loop_nest) {
+                output_img.print_loop_nest();
+            }
+            break;
         case Schedule::CPU:
 #if defined(WITH_DISTRIBUTE)
         case Schedule::CPUDistributed:
@@ -355,5 +443,7 @@ private:
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_distributed)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda)
+HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda_split)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda_distributed)
+HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_cuda_split_distributed)
 HALIDE_REGISTER_GENERATOR(BackprojectionGenerator, backprojection_auto_m16)

--- a/sarbp.cpp
+++ b/sarbp.cpp
@@ -21,9 +21,11 @@
 // Halide generators
 #include "backprojection.h"
 #include "backprojection_cuda.h"
+#include "backprojection_cuda_split.h"
 #if defined(WITH_DISTRIBUTE)
 #include "backprojection_distributed.h"
 #include "backprojection_cuda_distributed.h"
+#include "backprojection_cuda_split_distributed.h"
 #endif // WITH_DISTRIBUTE
 #include "backprojection_ritsar.h"
 #include "backprojection_ritsar_s.h"
@@ -76,7 +78,7 @@ static void print_usage(string prog, ostream& os) {
     os << "  -D, --db-max=REAL       Output image max dB" << endl;
     os << "                          Default: " << DB_MAX_DEFAULT << endl;
     os << "  -s, --schedule=NAME     One of: cpu[_distributed]" << endl;
-    os << "                                  cuda[_distributed]" << endl;
+    os << "                                  cuda[_split][_distributed]" << endl;
     os << "                                  ritsar[-s|-p|-vp]" << endl;
     os << "                                  auto-m16" << endl;
     os << "                          Default: " << SCHED_DEFAULT << endl;
@@ -198,11 +200,23 @@ int main(int argc, char **argv) {
     } else if (bp_sched == "cuda") {
         backprojection_impl = backprojection_cuda;
         cout << "Using schedule with CUDA" << endl;
+    } else if (bp_sched == "cuda_split") {
+        backprojection_impl = backprojection_cuda_split;
+        cout << "Using schedule with CUDA (split pulse)" << endl;
     } else if (bp_sched == "cuda_distributed") {
 #if defined(WITH_DISTRIBUTE)
         backprojection_impl = backprojection_cuda_distributed;
         is_distributed = true;
         cout << "Using schedule for distributed CUDA" << endl;
+#else
+        cerr << "Distributed schedules require distributed support in Halide" << endl;
+        return EXIT_FAILURE;
+#endif // WITH_DISTRIBUTE
+    } else if (bp_sched == "cuda_split_distributed") {
+#if defined(WITH_DISTRIBUTE)
+        backprojection_impl = backprojection_cuda_split_distributed;
+        is_distributed = true;
+        cout << "Using schedule for distributed CUDA (split pulse)" << endl;
 #else
         cerr << "Distributed schedules require distributed support in Halide" << endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
This adds a new CUDA schedule that splits execution across pulse, and attempts to limit the GPU usage to only what's needed to process a single pulse.

This is pretty similar to how RITSAR operates.  It will potentially have good scalability properties.  The GPU memory needs to contain the full image and full pixel coordinates, but those should decrease in size as the number of compute nodes increases.